### PR TITLE
Remove obsolete link to Sonar GNU/Linux

### DIFF
--- a/blog/20140925-ubuntu-mate-beta2.md
+++ b/blog/20140925-ubuntu-mate-beta2.md
@@ -31,7 +31,7 @@ already present in Beta1.
   * Added `gnome-system-tools` due to community feedback requesting user and time management facilities. [LP #1367772](https://bugs.launchpad.net/ubuntu-mate/+bug/1367772)  
   * Added indicators to Ubiquity that enable access to assistive features and basic system configuration.
   * Added assistive features to LightDM.
-  * Added keybindings, compatible with [Sonar](http://sonargnulinux.com/), for toggling assistive features.
+  * Added keybindings, compatible with Sonar GNU/Linux, for toggling assistive features.
   * Added a MATE panel layout that is similar in appearance to Windows XP classic mode (see below for activation instructions).
   * Updated the default Ubuntu MATE panel layout to better reflect how Ubuntu 10.04 and 10.10 were arranged.
   * Updated some icon assets in Ambiant-MATE and Radiant-MATE. Thanks to [Jack Mohegan](https://plus.google.com/101312215214323407176/posts/2dyVkArfx49).

--- a/pages/roadmap.md
+++ b/pages/roadmap.md
@@ -70,10 +70,10 @@ Making an accessible operating system was a key priority when the
 Ubuntu MATE founders initially set out the goals of the project.
 
 Ubuntu MATE is never going to be able to offer the comprehensive
-integration of assistive technologies that [Sonar GNU/Linux](http://sonargnulinux.com/)
-provides. But we will continue to follow their lead so that Ubuntu MATE
-is a viable desktop solution where computer access is shared within a
-household or business where individual needs differ.
+integration of assistive technologies that Sonar GNU/Linux provides. But
+we will continue to follow their lead so that Ubuntu MATE is a viable
+desktop solution where computer access is shared within a household or
+business where individual needs differ.
 
 The upstream MATE Desktop team are actively engaged with visually
 impaired users from the Linux community to ret and ensure their needs


### PR DESCRIPTION
It redirects to a click tracker parked domain.