### PR TITLE
Fixed documentation typo

### DIFF
--- a/pages/how-to-verify-downloads.md
+++ b/pages/how-to-verify-downloads.md
@@ -97,7 +97,7 @@ Graphical utilities are also available:
 ## Check using Repository GPG Keys (secure)
 
 This method verifies the hashes published by Canonical are
-actually authenticate. Unlike performing a quick checksum,
+actually authentic. Unlike performing a quick checksum,
 the SHA256SUMS file is signed and only Ubuntu's key can unlock
 the file to reveal the checksums exactly as Ubuntu published them.
 

--- a/pages/raspberry-pi.md
+++ b/pages/raspberry-pi.md
@@ -151,7 +151,7 @@ this is unnecessary on the Pi 3+ as USB booting is enabled by default.
 ### Re-size file system
 
 The root parition is automatically resized, on first boot, to fully utilise
-the all available space on the microSD card or USB stick. No reboots required.
+all the available space on the microSD card or USB stick. No reboots required.
 
 ### First boot
 
@@ -179,7 +179,7 @@ to enable SSH.
 
 If you install SSH then you might also want to install [sshguard](sshguard)
 which is highly optimised and well suited for use on the Raspberry Pi to
-protects from brute force attacks against SSH.
+protect from brute force attacks against SSH.
 
     sudo apt install sshguard
 
@@ -213,7 +213,7 @@ and use the Python interface to manipulate the world around you from the Raspber
 
 You can disable/enable the desktop environment using `raspi-config`.
 
-If you only intended to run as a headless server then the official Ubuntu Server 18.04.2 images mightt be of interest:
+If you only intended to run as a headless server then the official Ubuntu Server 18.04.2 images might be of interest:
 
   * <https://wiki.ubuntu.com/ARM/RaspberryPi>
 

--- a/pages/roadmap.md
+++ b/pages/roadmap.md
@@ -25,7 +25,7 @@ can work on and material to help them get started.
 ## Reboot Ubuntu MATE Welcome and Software Boutique
 
 We will decouple Ubuntu MATE Welcome and the Software Boutique so they
-can be interated on independently. The code for both will be refactor
+can be iterated on independently. The code for both will be refactored
 and simplified so that other projects wanting to build on either can
 easily do so.
 


### PR DESCRIPTION
When going through the documentation I noticed this, I believe the word should be authentic and not authenticate. Only my second PR in a few years so I hope I've done it correctly.