### PR TITLE
CSS: fix Slick button alignment on mobile devices

### DIFF
--- a/_sass/lib/slick.scss
+++ b/_sass/lib/slick.scss
@@ -113,7 +113,8 @@ $sm: 768px - 1px;
 $ss: 475px;
 @media (max-width: $ss) {
     .slick-dots {
-        width: calc(100% - (100vw / 4));
+        min-width: calc(100% - (100vw / 4));
+        max-width: calc(100% - (100vw / 4));
     }
     .slick-prev, .slick-dots, .slick-next {
         margin: 15px 0;

--- a/_sass/lib/slick.scss
+++ b/_sass/lib/slick.scss
@@ -109,3 +109,22 @@ $sm: 768px - 1px;
         width: calc(100% - 80px);
     }
 }
+
+$ss: 475px;
+@media (max-width: $ss) {
+    .slick-dots {
+        width: calc(100% - (100vw / 4));
+    }
+    .slick-prev, .slick-dots, .slick-next {
+        margin: 15px 0;
+    }
+    .slick-dots button {
+        margin: 0 1px 2px;
+        min-width: calc(100vw / 7);
+        max-width: calc(100vw / 7);
+    }
+    .slick-next, .slick-prev {
+        max-width: calc(100vw / 8);
+        min-width: calc(100vw / 8);
+    }
+}


### PR DESCRIPTION
Update fixes the Slick buttons on narrow devices with viewable screen sizes of 475px or less:

<img width="1000" alt="CSS Tweaks" src="https://user-images.githubusercontent.com/3123903/83355556-1a04c500-a39b-11ea-82e1-a20ef3c0ba54.png">

Testing with other devices shows a consistent appearance:

![CSS Tweaks 2](https://user-images.githubusercontent.com/3123903/83355572-386ac080-a39b-11ea-8af4-7aec3de2bc94.png)