### PR TITLE
CSS: fix for banner image skewing in Safari

### DIFF
--- a/_sass/_partials/_banner.scss
+++ b/_sass/_partials/_banner.scss
@@ -37,6 +37,10 @@
     }
 }
 
+.banner-inner img {
+    height: intrinsic;
+}
+
 .banner-text {
     display: inline-block;
     font-size: 24px;

--- a/_sass/_partials/_banner.scss
+++ b/_sass/_partials/_banner.scss
@@ -23,7 +23,7 @@
 
     img {
         display: inline-block;
-        height: auto;
+        height: max-content;
         width: 100%;
         max-width: 300px;
         margin: 15px;
@@ -35,10 +35,6 @@
         font-size: 0.8em;
         padding: 6px 16px;
     }
-}
-
-.banner-inner img {
-    height: intrinsic;
 }
 
 .banner-text {


### PR DESCRIPTION
Seems Safari doesn't like it when other OSes look good. This is how Safari shows the banner on MacOS 10.15.x:

<img width="1400" alt="Safari" src="https://user-images.githubusercontent.com/3123903/83430785-3a9f4e80-a471-11ea-96b8-eedcacf19740.png">

This is how Safari shows the banner on an iPad running iPad OS 13.5:

![iPad](https://user-images.githubusercontent.com/3123903/83430842-54d92c80-a471-11ea-859b-f57b7bccd751.png)

Neither of these are great. However, it can be resolved by using a *Safari-specific* value in the image CSS: `height: intrinsic`.

This will ensure the aspect ratio is maintained just like it is in Chrome:

<img width="1400" alt="Chrome" src="https://user-images.githubusercontent.com/3123903/83430970-86ea8e80-a471-11ea-8f46-f52a66f9f4da.png">

and Opera:

<img width="1400" alt="Opera" src="https://user-images.githubusercontent.com/3123903/83430989-8fdb6000-a471-11ea-84c6-416e74d1eef9.png">

and even Edge:

<img width="1400" alt="Edge" src="https://user-images.githubusercontent.com/3123903/83431008-97026e00-a471-11ea-952d-31a3c7660c6e.png">

Because `height: intrinsic` is not understood by any browser aside from Safari, and because there is no *good* way to write Safari-only CSS, the ugly kludge in this pull request was created. Testing shows that every non-Apple browser ignores the `intrinsic` and reads the existing `auto` value defined on line 26 of `_banner.scss`.