### PR TITLE
Updated Bug/Support Pages Take 2

### DIFF
--- a/pages/get-involved-bug-fixing.md
+++ b/pages/get-involved-bug-fixing.md
@@ -14,16 +14,16 @@ title: Bug Fixing
 If you're new to fixing bugs in Ubuntu MATE, and Ubuntu in general, you'll need
 a [Launchpad](https://bugs.launchpad.net/+login) account. This
 [Ubuntu Wiki page](https://wiki.ubuntu.com/HelpingWithBugs) is an excellent
-place to get started.
+place to learn about bug fixing in Ubuntu.
 
 ### Recommended Skills
 
-Although programming knowledge is very helpful in fixing bugs, there are some
-non-programming ways to handle reported and triaged issues. For example, there
-might be a typo or a problem with documentation. If you're proficient in a
-non-English language, you might fix a translation error. If you have Internet
-detective skills, you can track down fixes from upstream developers or other
-distributions.
+Although programming knowledge is very helpful, there are some
+non-programming ways to handle reported and triaged issues. For example, 
+there might be a typo or a problem with documentation. If you're proficient 
+in a non-English language, you might fix a translation error. If you have 
+Internet detective skills, you can track down fixes from upstream developers 
+or other distributions.
 
 ### Where to Start
 
@@ -33,17 +33,18 @@ its importance (`Undecided`, `Wishlist`, `Low`, `High`). If a bug is `New`, it's
 best to [triage the bug](/get-involved/bug-triage/), to at least be sure it's a
 confirmed bug.
 
-If you would like to start in a safe, bug-fixing sandbox, you can practice with
+If you would like to start in a safe bug-fixing sandbox, you can practice with
 the trivial bugs of the [One Hundred Papercuts](https://launchpad.net/hundredpapercuts)
 project.
 
 ### Learn More
 
-This [Ubuntu Wiki](https://wiki.ubuntu.com/Bugs/HowToFix) page walks users through fixing bugs in Ubuntu.
-Also, be sure to use the amazing resource that is the [Ubuntu MATE community](https://ubuntu-mate.community/c/support/10)!
-Lastly, this video, in addition to being a useful resource on Bug
-Triaging, also explains why it's important to make the fix in the right place,
-and why patching at the Ubuntu level (in the packages) is sometimes a better
-decision than only fixing upstream.
+This [Ubuntu Wiki](https://wiki.ubuntu.com/Bugs/HowToFix) page walks users 
+through fixing bugs in Ubuntu. Also, be sure to join the amazing resource 
+that is the [Ubuntu MATE community](https://ubuntu-mate.community/c/support/10)!
+
+Lastly, this video explains why it's important to fix bugs in the right 
+place, and why patching at the Ubuntu level (in the packages) is sometimes 
+better than only fixing upstream.
 
 {% include embed/youtube.html embed = "https://www.youtube.com/embed/kWojaWHl3U4?t=3732&rel=0" %}

--- a/pages/get-involved-bug-triage.md
+++ b/pages/get-involved-bug-triage.md
@@ -21,7 +21,7 @@ before you get started.
 
 ### How do I report a bug?
 
-[This tutorial](https://ubuntu-mate.community/t/how-to-report-problems-in-ubuntu-mate/17943) by APolihron, one of our QA testers,
+[This tutorial](https://ubuntu-mate.community/t/17943) by APolihron, one of our QA testers,
 demonstrates how to file a bug report. It is incredibly useful, 
 with gifs to illustrate each step of the process!
 

--- a/pages/get-involved-bug-triage.md
+++ b/pages/get-involved-bug-triage.md
@@ -14,7 +14,7 @@ title: Bug Reporting and Triage
 
 ### Where do I report a bug?
 
-All bugs go to [Launchpad - Ubuntu MATE bugs](https://bugs.launchpad.net/ubuntu-mate)
+Bugs are submitted to the [Ubuntu MATE project on Launchpad](https://bugs.launchpad.net/ubuntu-mate)
 
 If you don't already have an account, [set one up on Launchpad](https://help.launchpad.net/YourAccount/NewAccount)
 before you get started. 
@@ -67,4 +67,3 @@ fixers know where they need to focus their efforts.
 The video below shows bug triaging (and Martin!) in action:
 
 {% include embed/youtube.html embed = "https://www.youtube.com/embed/kWojaWHl3U4?t=3732&rel=0" %}
-

--- a/pages/get-involved-bug-triage.md
+++ b/pages/get-involved-bug-triage.md
@@ -23,7 +23,7 @@ before you get started.
 
 [This tutorial](https://ubuntu-mate.community/t/17943) by APolihron, one of our QA testers,
 demonstrates how to file a bug report. It is incredibly useful, 
-with gifs to illustrate each step of the process!
+with GIFs to illustrate each step of the process!
 
 ## Who can I talk to about bugs and bug reporting?
 

--- a/pages/get-involved-bug-triage.md
+++ b/pages/get-involved-bug-triage.md
@@ -12,53 +12,57 @@ title: Bug Reporting and Triage
 
 ## Bug Reporting
 
-### First Steps
+### Where do I report a bug?
 
-If you don't already have a Launchpad account, [set one up](https://help.launchpad.net/YourAccount/NewAccount)
-before you get started. Ubuntu uses Launchpad to track bugs and their fixes.
+All bugs go to [Launchpad - Ubuntu MATE bugs](https://bugs.launchpad.net/ubuntu-mate)
 
-### Is Your Bug a Bug
+If you don't already have an account, [set one up on Launchpad](https://help.launchpad.net/YourAccount/NewAccount)
+before you get started. 
 
-No, this isn't a weird philosophical question. Be sure to check the [community
-forum](https://ubuntu-mate.community) to see if your bug might just be a
-configuration issue. Make sure you also check the [release notes](/blog/) for
-your particular version of Ubuntu MATE, and also check [Launchpad](https://bugs.launchpad.net/ubuntu-mate) for
-any duplicate reports of your issue.
+### How do I report a bug?
 
-### Reporting Bugs in Ubuntu MATE
+[This tutorial](https://ubuntu-mate.community/t/how-to-report-problems-in-ubuntu-mate/17943) by APolihron, one of our QA testers,
+demonstrates how to file a bug report. It is incredibly useful, 
+with gifs to illustrate each step of the process!
 
-If your issue is indeed a bug, [this tutorial](https://ubuntu-mate.community/t/how-to-report-problems-in-ubuntu-mate/17943)
-is extremely helpful in showing the individual steps to file a
-report. Many thanks to APolihron, one of our QA testers, for making this!
+## Who can I talk to about bugs and bug reporting?
+
+Join the Ubuntu MATE community in the [Support and Help Requests](https://ubuntu-mate.community/c/support/10)
+section of the Community page to talk to new and experienced bug
+reporters! 
+
+
+
 
 
 ## Bug Triage
 
-Once bug reports are filed, the next step is to triage the bug. Much like
-medical staff prioritize patients based on the severity of their condition, bug
-triagers help teams determine which bugs are critical, and which are less
-urgent.
+If you're comfortable with bug reporting, bug triage is another great
+way to contribute to Ubuntu MATE!
+
+Bug triagers help teams determine which bugs are critical, and which are 
+less urgent.
 
 Some bug triage tasks require special privileges granted by project owners or
 administrators, but others simply require a [Launchpad](https://code.launchpad.net/ubuntu/+login) account.
-The key things you can do to help us prioritise bugs are as follows:
+Here are the key things you can do to help us prioritise bugs:
 
 * Can you reproduce a reported bug? If you can, write up the steps you followed
-to confirm the issue also exists for you.
+to confirm the issue.
 * If you confirmed the bug, could you also replicate the issue in stock Ubuntu
-or other flavours? Be sure your report indicates other affected flavours, or if
-the issue was limited to Ubuntu MATE.
-* However, if you can't reproduce the bug, can you get more information from the
+or other flavours? Your report should indicate if the bug affected other
+flavours, or it only affected Ubuntu MATE.
+* If you can't reproduce the bug, can you get more information from the
 original bug reporter?
-* Did you determine the bug was a duplicate? If so, mark one bug as a duplicate
+* Did you determine the bug was a duplicate? If you did, mark one bug as a duplicate
 of the other.
 * Did you determine the bug was filed with the wrong project? If so, re-open the
-bug with the right project and leave a note in the initial location.
+bug with the right project and leave a note in the bug's initial location.
 
-The initial work can help us realise where an error is, especially if the error
-is upstream. Bug triagers help make sure things are flowing as they should
-between upstream and downstream, and help bug fixers know where they need to
-focus their efforts.
+Bug triage can help us realise where an error is, especially if the error
+is upstream (for example, with the MATE Desktop instead of Ubuntu MATE.) 
+Bug triagers help maintain communication between projects and help bug 
+fixers know where they need to focus their efforts.
 
 The video below shows bug triaging (and Martin!) in action:
 

--- a/pages/support.md
+++ b/pages/support.md
@@ -7,21 +7,9 @@ class: support
 title: Support
 ---
 
-
-## Known Issues
-
-Here's a list of issues we have noted that may degrade your retrospective experience.
-
-{% include /partials/known-issues.html %}
-
-For a complete listing of Ubuntu MATE Bugs
-
-[Ubuntu MATE Bugs](https://bugs.launchpad.net/ubuntu-mate){:.btn .green}
-
-
 ## Community Support
 
-If your issue isn't listed above, we highly recommend asking on the
+If you need help, we encourage you to join fellow users in the
 [Ubuntu MATE Community](https://ubuntu-mate.community/). If this is your
 first time, you'll need to create a new account using the **Sign Up**
 button in the upper right hand corner. Once you have an account, post
@@ -33,9 +21,9 @@ your description of the problem and be excellent to each other.
 
 ## Official Guide
 
-If this is your first time using Ubuntu MATE, we have an official guide to
-assist you on your journey. It's also pre-installed under the **Accessories**
-menu (for full installations).
+If this is your first time using Ubuntu MATE, we have an official guide 
+to assist you on your journey. It's also pre-installed under the 
+**Accessories** menu (for full installations).
 
 [guide.ubuntu-mate.org](https://guide.ubuntu-mate.org){:.btn .green}
 [Shop Books](/shop/books/){:.btn}
@@ -52,3 +40,16 @@ to help the people who will help you.
 
 [Ask Ubuntu](https://askubuntu.com){:.btn}
 [Launchpad Answers](https://answers.launchpad.net/){:.btn}
+
+## Known Issues
+
+Here's a list of issues we have noted that may degrade your retrospective experience.
+
+{% include /partials/known-issues.html %}
+
+For a complete listing of Ubuntu MATE Bugs
+
+[Ubuntu MATE Bugs](https://bugs.launchpad.net/ubuntu-mate){:.btn .green}
+
+To learn how to report a bug, go to [Bug Reporting and Triage](/get-involved/bug-triage/){:.btn}
+

--- a/pages/support.md
+++ b/pages/support.md
@@ -47,8 +47,8 @@ Here's a list of issues we have noted that may degrade your retrospective experi
 
 {% include /partials/known-issues.html %}
 
-For a complete listing of Ubuntu MATE Bugs
+For a complete listing of Ubuntu MATE Bugs:
 
-[Ubuntu MATE Bugs](https://bugs.launchpad.net/ubuntu-mate){:.btn .green}
+[Ubuntu MATE Bugs on Launchpad](https://bugs.launchpad.net/ubuntu-mate){:.btn .green}
 
 To learn how to report a bug, go to [Bug Reporting and Triage](/get-involved/bug-triage/) under [Get Involved](/get-involved/).

--- a/pages/support.md
+++ b/pages/support.md
@@ -51,5 +51,4 @@ For a complete listing of Ubuntu MATE Bugs
 
 [Ubuntu MATE Bugs](https://bugs.launchpad.net/ubuntu-mate){:.btn .green}
 
-To learn how to report a bug, go to [Bug Reporting and Triage](/get-involved/bug-triage/){:.btn}
-
+To learn how to report a bug, go to [Bug Reporting and Triage](/get-involved/bug-triage/) under [Get Involved](/get-involved/).


### PR DESCRIPTION
Clarified bug-triage and bug-fixing, added more explicit links to Ubuntu MATE Launchpad page, emphasized community resources for Support page.