### PR TITLE
Update known issues for Clock missing in panel

### DIFF
--- a/_data/known_issues.yml
+++ b/_data/known_issues.yml
@@ -71,3 +71,11 @@
     #-
   upstream_links:
     - https://bugs.launchpad.net/ubuntu-mate/+bug/1884379
+    
+- release: 20.10
+  component: Ayatana Indicators
+  problem: Clock missing on panel upon upgrade to 20.10
+  workaround_links:
+    - https://ubuntu-mate.community/t/ubuntu-testing-week-ubuntu-mate-20-10/22259/40
+  upstream_links:
+    - https://bugs.launchpad.net/ubuntu/+source/ayatana-indicator-datetime/+bug/1893028

--- a/_data/known_issues.yml
+++ b/_data/known_issues.yml
@@ -72,7 +72,7 @@
   upstream_links:
     - https://bugs.launchpad.net/ubuntu-mate/+bug/1884379
     
-- release: 20.10
+- release: "20.10"
   component: Ayatana Indicators
   problem: Clock missing on panel upon upgrade to 20.10
   workaround_links:


### PR DESCRIPTION
Clock not appearing on panel upon upgrade to 20.10