### PR TITLE
Missing translate-toolkit package to build the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To install gem dependencies for the project;
 
 Some additional packages are needed to build the project:
 
-    sudo apt install python3-yaml transmission-cli python3-polib
+    sudo apt install python3-yaml transmission-cli python3-polib translate-toolkit
 
 To watch for changes locally:
 


### PR DESCRIPTION
On ubuntu 20.10, I needed to add the `translate-toolkit` package to be able to build the website.