### PR TITLE
Fix RSS modification dates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+      with: { fetch-depth: 0 }
 
     - name: Cache RubyGems
       uses: actions/cache@v2
@@ -30,6 +31,13 @@ jobs:
         sudo apt-get install transmission-cli python3-requests python3-yaml translate-toolkit rsync python3-polib webp
         bundle config path vendor/bundle
         bundle install --jobs=4
+
+    # Some RSS clients think all blog posts were modified at time of deploy.
+    # https://stackoverflow.com/a/36243002
+    - name: Restore blog modification times
+      run: |
+        rev=$(git branch --show-current)
+        for f in $(git ls-tree -r -t --full-name --name-only "$rev"); do touch -d $(git log --pretty=format:%cI -1 "$rev" -- "$f") "$f"; done
 
     - name: Build Website
       run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.2.1)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,13 +17,13 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    ffi (1.14.2)
+    ffi (1.15.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     html-pipeline (2.14.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (3.18.5)
+    html-proofer (3.18.8)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)
@@ -32,7 +32,7 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.6.0)
-    i18n (1.8.8)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.0)
       addressable (~> 2.4)
@@ -64,21 +64,21 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.4.1)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
-    nokogiri (1.11.1)
+    minitest (5.14.4)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogumbo (2.0.4)
+    nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.20.1)
     pathutil (0.16.2)
@@ -118,4 +118,4 @@ DEPENDENCIES
   jemoji
 
 BUNDLED WITH
-   2.2.8
+   2.2.15


### PR DESCRIPTION
It seems some RSS clients use `<updated>` instead of `<published>` in `/feed.xml` to determine if there's changes to posts. Up to now, the "updated" date was being reset to the time of deployment.

This corrects the dates by using the git timestamp for the file. This does **not** fix RSS localized versions of the site, as those files are generated at build time. Some additional work would be needed to fix it there.

Also some general maintenance -- I ran `bundle update` to bump to the latest versions.