### PR TITLE
Fix downloads.yml for hirsute

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -45,7 +45,7 @@ releases:
         wallpaper: "focal.jpg"
         lts: false
         prerelease: false
-        release_notes: "/blog/ubuntu-mate-hirsute-hippo-release-notes/"
+        release_notes: "/blog/ubuntu-mate-hirsute-hippo-final-release/"
         end_of_life:
             month: Jan
             year: 2022

--- a/_data/feature-grid.yml
+++ b/_data/feature-grid.yml
@@ -95,6 +95,7 @@
     - name: Redshift
       icon: /images/apps/redshift.svg
       not_in_min_install: true
+      class: "not-in-21-04"
 
     - name: Firefox
       icon: /images/apps/firefox.svg

--- a/_data/known_issues.yml
+++ b/_data/known_issues.yml
@@ -84,13 +84,13 @@
   component: Plank
   problem: When snaps update, they disappear from Plank.
   upstream_links:
-    https://bugs.launchpad.net/plank/+bug/1828030
+    - https://bugs.launchpad.net/plank/+bug/1828030
 
 - release: "21.04"
   component: Ubuntu MATE
   problem: Screen reader installs using orca are currently not working
   upstream_links:
-    https://bugs.launchpad.net/plank/+bug/1231091
+    - https://bugs.launchpad.net/plank/+bug/1231091
 
 - release: "21.04"
   component: Ubuntu
@@ -98,4 +98,10 @@
   workaround_links:
     - https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1713720/comments/4
   upstream_links:
-    https://bugs.launchpad.net/plank/+bug/1713720
+    - https://bugs.launchpad.net/plank/+bug/1713720
+
+- release: "21.04"
+  component: Ubuntu
+  problem: Shim-signed causes system not to boot on certain older EFI systems
+  upstream_links: 
+    - https://bugs.launchpad.net/ubuntu/+source/shim/+bug/1925010

--- a/_layouts/feature-grid.html
+++ b/_layouts/feature-grid.html
@@ -25,6 +25,7 @@ layout: default
                         <select id="filter-distro" class="feature-filter" onchange="refresh_feature_filters()">
                             <option name="not-in-20-10">20.10</option>
                             <option name="not-in-20-04">20.04 LTS</option>
+                            <option name="not-in-21-04">21.04</option>
                         </select>
                     </label>
                     <label>

--- a/_posts/2021-04-22-ubuntu-mate-hirsute.md
+++ b/_posts/2021-04-22-ubuntu-mate-hirsute.md
@@ -1,7 +1,7 @@
 ---
 layout: blog-post
 class: blog
-permalink: /blog/ubuntu-mate-hirsute-hippo-release-notes/
+permalink: /blog/ubuntu-mate-hirsute-hippo-final-release/
 category: release
 author: Martin Wimpress & Monica Ayhens-Madon
 lang: en

--- a/_posts/2021-04-22-ubuntu-mate-hirsute.md
+++ b/_posts/2021-04-22-ubuntu-mate-hirsute.md
@@ -1,7 +1,7 @@
 ---
 layout: blog-post
 class: blog
-permalink: /blog/ubuntu-mate-hirsute-hippo-final-release/
+permalink: /blog/ubuntu-mate-hirsute-hippo-release-notes/
 category: release
 author: Martin Wimpress & Monica Ayhens-Madon
 lang: en


### PR DESCRIPTION
Resolve 404 error on Downloads page for Release Notes. Update feature-grid for 21.04