### PR TITLE
Condense download index page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -68,42 +68,21 @@ layout: default
                         </a>
                     </div>
                 {% endfor %}
-            </div>
 
-            <div class="row">
-                <div class="col">
-                    <p class="text-center grey-text">
-                        <a href="/about/requirements/">{{ site.data.strings.show_req }}</a> |
-                        <a href="/faq/downloads/">{{ site.data.strings.download_help }}</a>
-                    </p>
+                <div class="col-md-6 arch-links-box">
+                    <a href="/about/requirements/">
+                        {% include images/fa/check.svg %}
+                        {{ site.data.strings.show_req }}
+                    </a>
+                    <a href="/faq/downloads/">
+                        {% include images/fa/question-circle.svg %}
+                        {{ site.data.strings.download_help }}
+                    </a>
+                    <a href="https://releases.ubuntu-mate.org">
+                        {% include images/fa/folder-open.svg %}
+                        {{ site.data.strings.browse_downloads }}
+                    </a>
                 </div>
-            </div>
-
-            <div class="row">
-                <div class="col">
-                    <h3 class="download-subtitle">{{ site.data.strings.download_products }}</h3>
-                </div>
-            </div>
-
-            <div class="row grid-container">
-                {% for product in page.products %}
-                    <div class="col-md-6">
-                        <a class="grid-item" href="{{ product.url }}">
-                            <div class="grid-icon">
-                                {% capture icon_type %}{{ product.icon | slice:-3,3 }}{% endcapture %}
-                                {% if icon_type == 'svg' %}
-                                    {% include {{ product.icon }} %}
-                                {% else %}
-                                    <img src="{{ product.icon }}" alt=""/>
-                                {% endif %}
-                            </div>
-                            <div class="grid-details">
-                                <h4>{{ product.name }}</h4>
-                                {{ product.desc | markdownify }}
-                            </div>
-                        </a>
-                    </div>
-                {% endfor %}
             </div>
 
             <div class="row">
@@ -135,13 +114,29 @@ layout: default
 
             <div class="row">
                 <div class="col">
-                    <p class="text-center grey-text">
-                        <a href="https://releases.ubuntu-mate.org">
-                            {% include images/fa/folder-open.svg %}
-                            {{ site.data.strings.browse_downloads }}
-                        </a>
-                    </p>
+                    <h3 class="download-subtitle">{{ site.data.strings.download_products }}</h3>
                 </div>
+            </div>
+
+            <div class="row grid-container">
+                {% for product in page.products %}
+                    <div class="col-md-6">
+                        <a class="grid-item" href="{{ product.url }}">
+                            <div class="grid-icon">
+                                {% capture icon_type %}{{ product.icon | slice:-3,3 }}{% endcapture %}
+                                {% if icon_type == 'svg' %}
+                                    {% include {{ product.icon }} %}
+                                {% else %}
+                                    <img src="{{ product.icon }}" alt=""/>
+                                {% endif %}
+                            </div>
+                            <div class="grid-details">
+                                <h4>{{ product.name }}</h4>
+                                {{ product.desc | markdownify }}
+                            </div>
+                        </a>
+                    </div>
+                {% endfor %}
             </div>
 
         {% elsif page.step == 2 %}

--- a/_sass/_layouts/_downloads.scss
+++ b/_sass/_layouts/_downloads.scss
@@ -116,6 +116,25 @@
     color: $danger;
 }
 
+.arch-links-box {
+    display: flex;
+    flex-direction: column;
+
+    a {
+        display: inline-block;
+        margin: 15px 0;
+        margin-right: auto;
+
+        &:first-child {
+            margin-top: auto;
+        }
+
+        &:last-child {
+            margin-bottom: auto;
+        }
+    }
+}
+
 /* Download Details */
 .download-details {
     display: flex;


### PR DESCRIPTION
Now that i386 is gone, it would be nice to use less whitespace and bring the device ports and links closer to the top.

### Before
![Screenshot_20210721_112919](https://user-images.githubusercontent.com/13032135/126474910-c78e2b08-84c4-44bf-bf83-f0310523c18e.png)

### After
![Screenshot_20210721_112923](https://user-images.githubusercontent.com/13032135/126474915-ec0b206d-f9e1-4ac1-91b7-a09c10a67490.png)
