### PR TITLE
Fix a typo in raspberry-pi-compatibility.md

### DIFF
--- a/pages/raspberry-pi-compatibility.md
+++ b/pages/raspberry-pi-compatibility.md
@@ -25,7 +25,7 @@ Good question! [This is answered on our Raspberry Pi Download page.](/raspberry-
 
 Memory pressure is reasonable using the `armhf` images (~350MB at idle)
 but quite tight on the `arm64` images (~490MB at idle). As always,
-microSDHC I/O throughput is a bottleneck on the Raspberry PPi so don't
+microSDHC I/O throughput is a bottleneck on the Raspberry Pi so don't
 gimp your Raspberry Pi by cheaping out on poor performing microSDHC
 cards. We used the [Samsung EVO Plus 32 GB microSDHC UHS-I U1](https://geni.us/AKAsg)
 and [Kingston 64 GB microSDXC Canvas Go Plus](https://geni.us/Jelmu)


### PR DESCRIPTION
Fix a typo in [raspberry-pi-compatibility.md](https://github.com/ubuntu-mate/ubuntu-mate.org/blob/master/pages/raspberry-pi-compatibility.md)

# Raspberry PPi -> Raspberry Pi