### PR TITLE
Remove duplicated word (typo – "get get")

### DIFF
--- a/_posts/2022-03-29-ubuntu-mate-jammy.md
+++ b/_posts/2022-03-29-ubuntu-mate-jammy.md
@@ -180,7 +180,7 @@ The Software Boutqiue has been restocked with software for 22.04 and
 
 ### 41% less fat 🍩
 
-Ubuntu MATE, like it's lead developer, was starting to get get a bit large
+Ubuntu MATE, like it's lead developer, was starting to get a bit large
 around the mid section 😊 **During the development of 22.04, the image 📀 got
 to 4.1GB 😮**
 


### PR DESCRIPTION
I noticed a typo in the release notes for Ubuntu MATE 22.04. The word "get" is repeated twice. This PR removes the duplication.