### PR TITLE
Fix typo ("Boutqiue") in the Ubuntu Jammy Release Notes

### DIFF
--- a/_posts/2022-03-29-ubuntu-mate-jammy.md
+++ b/_posts/2022-03-29-ubuntu-mate-jammy.md
@@ -171,7 +171,7 @@ toolkit or compositor being used.
 
 #### Ubuntu MATE Welcome & Boutique
 
-The Software Boutqiue has been restocked with software for 22.04 and
+The Software Boutique has been restocked with software for 22.04 and
 **Firefox 🔥🦊 ESR (`.deb`) has been added to the Browser Ballot in Ubuntu MATE Welcome.**
 
 {:.center}


### PR DESCRIPTION
Fix typo (corrected "Boutqiue" to "Boutique") 
in the Ubuntu MATE 22.04 LTS Release Notes.