### PR TITLE
Change word "compliment" to "complement"

### DIFF
--- a/_posts/2022-09-29-ubuntu-mate-kinetic.md
+++ b/_posts/2022-09-29-ubuntu-mate-kinetic.md
@@ -160,7 +160,7 @@ panel offsets/struts), **is highly configurable and includes a new HUD settings 
 
 #### MATE User Manager
 
-**A new utility, User Manager, has been added to compliment the suite of MATE
+**A new utility, User Manager, has been added to complement the suite of MATE
 tools.** User Manager replaces the aging `gnome-system-tools` which was
 removed from Ubuntu MATE in the 22.04 release and allows you to add/modify/remove
 user accounts. It also includes the ability to define which users are Administrators,


### PR DESCRIPTION
Changed word "compliment" to "complement" in the following sentence of  the "Ubuntu MATE 22.10" Release Notes:

"A new utility, User Manager, has been added to complement the suite of MATE tools."