### PR TITLE
Change "pt_BL" to "pt_BR" in "Known Issues"

### DIFF
--- a/_data/known_issues.yml
+++ b/_data/known_issues.yml
@@ -1,6 +1,6 @@
 - release: 20.04 LTS
   component: Ubuntu MATE
-  problem: Some locales (like pt_BL) are missing menu icons.
+  problem: Some locales (like pt_BR) are missing menu icons.
   workaround_links:
     - https://ubuntu-mate.community/t/21579/13
   upstream_links:


### PR DESCRIPTION
The "Brazilian Portuguese" locale is "pt_BR" and not "pt_BL"  (there is no locale that is called "pt_BL").

Fixing the known issues reference for Ubuntu MATE 20.04 accordingly.