### PR TITLE
Update downloads.yml to correct ISO size for focal

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -70,7 +70,7 @@ downloads:
         - release: focal
           url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/20.04/release/ubuntu-mate-20.04.5-desktop-amd64.iso"
           sha256sum: "cf90f3de070f2ed1cd6f60de16a197e6dad1b90c3898af165b0979561e449bbc"
-          size: "3.2 GB"
+          size: "4.1 GB"
           magnet-uri: "magnet:?xt=urn:btih:50b3bc19c6eb3f78478d74f389f56b50bd45ddcd&dn=ubuntu-mate-20.04.5-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
         - release: jammy


### PR DESCRIPTION
Update downloads.yml to correct ISO size for Ubuntu MATE 20.04.5 (Focal Fossa)

The file "ubuntu-mate-20.04.5-desktop-amd64.iso" is 4.1 GB in size and not 3.2 GB