### PR TITLE
Update AMD64 downloads data to 22.04.2

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -27,7 +27,7 @@ releases:
             year: 2022
 
     jammy:
-        name: "22.04.1 LTS"
+        name: "22.04.2 LTS"
         codename: "Jammy Jellyfish"
         mascot: "jammy.svg"
         wallpaper: "focal.jpg"
@@ -74,10 +74,10 @@ downloads:
           magnet-uri: "magnet:?xt=urn:btih:50b3bc19c6eb3f78478d74f389f56b50bd45ddcd&dn=ubuntu-mate-20.04.5-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
         - release: jammy
-          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.1-desktop-amd64.iso"
-          sha256sum: "1c18cdabcf820f699cebf6cda7ed4ba230d9acaf0b1573b870b099f678d32c29"
-          size: "2.5 GB"
-          magnet-uri: "magnet:?xt=urn:btih:de9bff3b76489706867baa8021d7e3367998ebba&dn=ubuntu-mate-22.04.1-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
+          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.2-desktop-amd64.iso"
+          sha256sum: "d367d6e03ef576cc9c58598485ea9e19bae94ad2f2578655ff02b06cdd091fd4"
+          size: "3.1 GB"
+          magnet-uri: "magnet:?xt=urn:btih:e7088644335bd66118c01d3e4ece64f2630fb1c6&dn=ubuntu-mate-22.04.2-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
         - release: kinetic
           url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/22.10/release/ubuntu-mate-22.10-desktop-amd64.iso"


### PR DESCRIPTION
I went to download Ubuntu MATE 22.04 for AMD64 and noticed that the download links are dead. By going to [the Ubuntu releases download page](https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/), it looks like everything was updated to 22.04.2 yesterday, and the old resources are gone. I believe that this PR will bump everything accordingly from 22.04.1 to 22.04.2.