### PR TITLE
Replaced Update Manager reference from 22.10 to 23.04

### DIFF
--- a/_posts/2023-04-20-ubuntu-mate-lunar-lobster.md
+++ b/_posts/2023-04-20-ubuntu-mate-lunar-lobster.md
@@ -81,7 +81,7 @@ upgrade.
   * Select the 3rd Tab called "Updates".
   * Set the "Notify me of a new Ubuntu version" drop down menu to "For any new version".
   * Press <kbd>Alt</kbd>+<kbd>F2</kbd> and type in `update-manager -c -d` into the command box.
-  * Update Manager should open up and tell you: New distribution release '22.10' is available.
+  * Update Manager should open up and tell you: New distribution release '23.04' is available.
     * If not, you can use `/usr/lib/ubuntu-release-upgrader/check-new-release-gtk`
   * Click "Upgrade" and follow the on-screen instructions.
 


### PR DESCRIPTION
Replaced the following Update Manager mention in 
the Ubuntu MATE 23.04 Release Notes:

"New distribution release '22.10' is available"

by the following one:

"New distribution release '23.04' is available"