### PR TITLE
blog : replace video URL about MATE pronunciation

### DIFF
--- a/_posts/2014-07-14-how-to-say-mate.md
+++ b/_posts/2014-07-14-how-to-say-mate.md
@@ -17,9 +17,9 @@ Let's stop with the *"mait"* and the *"matey"*. It is pronounced
 Claude van Damme round to give you some elocution lessons `;-)`
 
 {% include embed/youtube.html
-    embed = "https://www.youtube.com/embed/k0YDuSLXcX8?html5=1&rel=0&start=459&end=472"
+    embed = "https://www.youtube.com/embed/AAqzdnNnvSQ?html5=1&rel=0"
 %}
 
-Thanks to [Michael Tunnell](https://plus.google.com/+MichaelTunnell/posts)
+Thanks to [Michael Tunnell](https://www.youtube.com/@michael_tunnell)
 for originally sharing this joke with the MATE developers a few months
 back.


### PR DESCRIPTION
The YouTube video URL to the video by Michael Tunnell that 
explains how to pronounce MATE stopped working (it is 
showing the "This video is unavailable" error message).
So I am replacing that URL by another YouTube URL also by 
Michael Tunnell (maybe it is the same video as the original but 
in another location).
    
Besides that, due to the end of Google Plus, the link to Michael Tunnell's 
posts in Google Plus also stopped working. So, I am replacing that URL 
by a link to his YouTube channel.
