### PR TITLE
feat: update downloads for 22.04 from 22.04.3 to 22.04.4

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -27,7 +27,7 @@ releases:
             year: 2022
 
     jammy:
-        name: "22.04.3 LTS"
+        name: "22.04.4 LTS"
         codename: "Jammy Jellyfish"
         mascot: "jammy.svg"
         wallpaper: "focal.jpg"
@@ -71,10 +71,10 @@ arch:
 downloads:
     amd64:
         - release: jammy
-          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.3-desktop-amd64.iso"
-          sha256sum: "d84cd3eb7732fbb39ce3cd24ba1b302a643fe0362f7ac9261fc4c7b756e42a55"
+          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.4-desktop-amd64.iso"
+          sha256sum: "09f52b8bac46e3cf07e90bc4ed9f3dd1a0efe0ff3fc65d9edd8c639cb6dcb391"
           size: "3.5 GB"
-          magnet-uri: "magnet:?xt=urn:btih:0223dcb7785d09dbdff5839a089774277a66b4c9&dn=ubuntu-mate-22.04.3-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
+          magnet-uri: "magnet:?xt=urn:btih:f9623b09f6e2d07060678557f7b5263440b3cdfa&dn=ubuntu-mate-22.04.4-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
         - release: lunar
           url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/23.04/release/ubuntu-mate-23.04-desktop-amd64.iso"


### PR DESCRIPTION
As @guiverc (Chris Guiver) has mentioned in:

https://ubuntu-mate.community/t/site-links-need-updating/27181

... "Ubuntu 22.04.4 (and flavors) were released":

https://fridge.ubuntu.com/2024/02/22/ubuntu-22-04-4-lts-released/

But the download links at:

https://ubuntu-mate.org/download/amd64/jammy/ 

... are still pointing to :

https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.3-desktop-amd64.iso

.... which no longer exists (returns a 404 error). 

This commit and Pull Request replaces "22.04.3" by "22.04.4"  in the version number, and updates the SHA256 checksum and Magnet link accordingly.