### PR TITLE
Removing 23.04 from downloads as it went EOL

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -76,12 +76,6 @@ downloads:
           size: "3.5 GB"
           magnet-uri: "magnet:?xt=urn:btih:f9623b09f6e2d07060678557f7b5263440b3cdfa&dn=ubuntu-mate-22.04.4-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
-        - release: lunar
-          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/23.04/release/ubuntu-mate-23.04-desktop-amd64.iso"
-          sha256sum: "6568d221adb8682d8addae8d09d8d87ecbaaab8a1d4c1119e8cc960e49530fdb"
-          size: "3.3 GB"
-          magnet-uri: autogen
-
         - release: mantic
           url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/23.10/release/ubuntu-mate-23.10-desktop-amd64.iso"
           sha256sum: "775028938f1615f19843e70335fa9d6b17d5667b3b176ec013e3ec625225450c"


### PR DESCRIPTION
Ubuntu 23.04 ("Lunar Lobster") reached EOL (End Of Life)  as of 25th January 2024. So, this Commit and "Pull Request"  serves to remove the download links for "23.04" from  https://ubuntu-mate.org/download/amd64/

REFERENCES:

1 - @guiverc (Chris Guiver) post in: 

https://fridge.ubuntu.com/2024/01/26/ubuntu-23-04-lunar-lobster-reached-end-of-life-on-january-25-2024/

2 - ... which, as that post mentions, is a repost of a "ubuntu-announce" mailing list post by Brian Murray available in:  https://lists.ubuntu.com/archives/ubuntu-announce/2024-January/000298.html