### PR TITLE
fix: Update downloads.yml to correct version of Noble Numbat

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -51,7 +51,7 @@ releases:
             year: 2024
 
     noble:
-        name: "22.04 LTS"
+        name: "24.04 LTS"
         codename: "Noble Numbat"
         mascot: "noble.svg"
         wallpaper: "focal.jpg"


### PR DESCRIPTION
As tkn (thom) has correctly mentioned, in an Ubuntu MATE  Community post, the downloads page has a small typo, by referring to Noble Numbat as being 22.04 when it should be 24.04. This commit and pull request fixes that. 

REFERENCES:

https://ubuntu-mate.community/t/small-typo-on-download-page-numbat-22-04-instead-of-24-04/27280
