### PR TITLE
Removing 23.10 from downloads as it went EOL

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -76,12 +76,6 @@ downloads:
           size: "3.5 GB"
           magnet-uri: "magnet:?xt=urn:btih:8fcb95f456700f9938c049ccb2ce60c423e2b6fa&dn=ubuntu-mate-22.04.5-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
-        - release: mantic
-          url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/23.10/release/ubuntu-mate-23.10-desktop-amd64.iso"
-          sha256sum: "775028938f1615f19843e70335fa9d6b17d5667b3b176ec013e3ec625225450c"
-          size: "3.3 GB"
-          magnet-uri: "magnet:?xt=urn:btih:b7fd0b576ef55e2f65aeaf164b40d5f63fb685d5&dn=ubuntu-mate-23.10-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
-
         - release: noble
           url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/noble/release/ubuntu-mate-24.04.1-desktop-amd64.iso"
           sha256sum: "e2f336fe046fa399331bf09c7b5c86b9a75a9c30491bd8cd3dff9745b195d06e"


### PR DESCRIPTION
Ubuntu 23.10 ("Mantic Minotaur") reached EOL (End Of Life)  as of 11th July 2024. So, this Commit and "Pull Request"  serves to remove the download links for "23.10" from  https://ubuntu-mate.org/download/amd64/

REFERENCES:

1 - @guiverc (Chris Guiver) post in: 

https://ubuntu-mate.community/t/ubuntu-mate-23-10-is-now-end-of-life-11-july-2024/27976

2 - ... which indirectly references an "ubuntu-announce" mailing list post by Graham Inggs available in: 

https://lists.ubuntu.com/archives/ubuntu-announce/2024-June/000302.html