### PR TITLE
Update 2025-04-15-ubuntu-mate-plucky-puffin.md: Kernel is 6.14

### DIFF
--- a/_posts/2025-04-15-ubuntu-mate-plucky-puffin.md
+++ b/_posts/2025-04-15-ubuntu-mate-plucky-puffin.md
@@ -28,7 +28,7 @@ Here are the highlights of what's new in the Plucky Puffin release:
 
 ## Major Applications
 
-Accompanying **MATE Desktop** 🧉 and **Linux 6.15** 🐧 are **Firefox 137** 🔥🦊,
+Accompanying **MATE Desktop** 🧉 and **Linux 6.14** 🐧 are **Firefox 137** 🔥🦊,
 **Evolution 3.56** 📧, **LibreOffice 25.2.2** 📚
 
 See the [Ubuntu 25.04 Release Notes](https://discourse.ubuntu.com/t/plucky-puffin-release-notes/48687) 


### PR DESCRIPTION
As Chris Guiver (@guiverc) has pointed out in 
https://ubuntu-mate.community/t/typo-in-ubuntu-mate-25-04-release-notes/29294

... the version of the Linux Kernel in Ubuntu MATE 25.04 ("Plucky Puffin") is 6.14 and not 6.15

This commit and pull request makes that correction.