### PR TITLE
Update downloads.yml : Removing 24.10 from downloads as it went EOL

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -17,24 +17,6 @@ codenames:
                 size: "4.1 GB"
                 magnet-uri: "magnet:?xt=urn:btih:d6663939e41a8ba70ea153a34a17f896e084fd58&dn=ubuntu-mate-24.04.2-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
-    oracular:
-        name: "24.10"
-        codename: "Oracular Oriole"
-        mascot: "oracular.svg"
-        lts: false
-        old_lts: false
-        beta: false
-        release_notes: "/blog/ubuntu-mate-oracular-oriole-release-notes/"
-        end_of_life:
-            month: Jul
-            year: 2025
-        releases:
-            amd64:
-                url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/24.10/release/ubuntu-mate-24.10-desktop-amd64.iso"
-                sha256sum: "6139a5f9bd00bac15a50e013b1f80f39098c5c4290b1f052cf88bc27871b9ae7"
-                size: "3.3 GB"
-                magnet-uri: "magnet:?xt=urn:btih:bae16ce3d55349d55e41778b61c1890e21bf275b&dn=ubuntu-mate-24.10-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
-
     plucky:
         name: "25.04"
         codename: "Plucky Puffin"


### PR DESCRIPTION
Ubuntu 24.10 ("Oracular Oriole") reached EOL (End Of Life)  as of 10th July 2025. So, this Commit and "Pull Request"  serves to remove the download links for "24.10" from  https://ubuntu-mate.org/download/amd64/

REFERENCES:

1 - https://discourse.ubuntu.com/t/ubuntu-24-10-oracular-oriole-reached-end-of-life-on-10th-july-2025/64289

2 - https://fridge.ubuntu.com/2025/07/10/ubuntu-24-10-oracular-oriole-reached-end-of-life-on-10th-july-2025/

3 - https://lists.ubuntu.com/archives/ubuntu-announce/2025-July/000314.html