### PR TITLE
Fix broken download links due to the release of 24.04.3

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -1,6 +1,6 @@
 codenames:
     noble:
-        name: "24.04.2 LTS"
+        name: "24.04.3 LTS"
         codename: "Noble Numbat"
         mascot: "noble.svg"
         lts: true
@@ -12,10 +12,10 @@ codenames:
             year: 2027
         releases:
             amd64:
-                url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/noble/release/ubuntu-mate-24.04.2-desktop-amd64.iso"
-                sha256sum: "ec1399cf90678c29ee1f80055826b21a3d90f59d50d154e5ea70b1931ce909c9"
+                url: "https://cdimage.ubuntu.com/ubuntu-mate/releases/noble/release/ubuntu-mate-24.04.3-desktop-amd64.iso"
+                sha256sum: "370b6f05935b7ef350eff2c5eb912c0fcf4c42c9ac2b246f2f9249cfb7d09151"
                 size: "4.1 GB"
-                magnet-uri: "magnet:?xt=urn:btih:d6663939e41a8ba70ea153a34a17f896e084fd58&dn=ubuntu-mate-24.04.2-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
+                magnet-uri: "magnet:?xt=urn:btih:d05715a53b0ae9afec3ebcbcc2a5d10c7c55e2f8&dn=ubuntu-mate-24.04.3-desktop-amd64.iso&tr=https%3A%2F%2Ftorrent.ubuntu.com%2Fannounce"
 
     plucky:
         name: "25.04"


### PR DESCRIPTION
Updated download page for 24.04.3. Current links are pointing to 24.04.2 which no longer exists on the mirror.